### PR TITLE
docker entrypoints: further explain format

### DIFF
--- a/scripts/docker/entrypoint-smp-server
+++ b/scripts/docker/entrypoint-smp-server
@@ -32,7 +32,8 @@ fi
 # for both time zone and month (M)/day (D).
 #
 # Uses the UTC (universal) time zone and this
-# format: YYYY-0MM-DD'T'hh:mm:ss
+# format: YYYY-0mm-dd'T'HH':'MM':'SS
+# year, month, day, letter T, hour, minute, second
 #
 _file="${logd}/smp-server-store.log"
 if [ -f "${_file}" ]; then

--- a/scripts/docker/entrypoint-xftp-server
+++ b/scripts/docker/entrypoint-xftp-server
@@ -32,7 +32,8 @@ fi
 # for both time zone and month (M)/day (D).
 #
 # Uses the UTC (universal) time zone and this
-# format: YYYY-0MM-DD'T'hh:mm:ss
+# format: YYYY-0mm-dd'T'HH':'MM':'SS
+# year, month, day, letter T, hour, minute, second
 #
 _file="${logd}/file-server-store.log"
 if [ -f "${_file}" ]; then


### PR DESCRIPTION
I fixed the case to match the date format letters.

Also, use words to explain since I don't want everyone to need to read about date formats to understand.