### PR TITLE
docker entrypoints: remove %F

### DIFF
--- a/scripts/docker/entrypoint-smp-server
+++ b/scripts/docker/entrypoint-smp-server
@@ -36,7 +36,7 @@ fi
 #
 _file="${logd}/smp-server-store.log"
 if [ -f "${_file}" ]; then
-  _backup_extension="$(date -u '+%FT%T')"
+  _backup_extension="$(date -u '+%Y-%m-%dT%H:%M:%S')"
   cp -v -p "${_file}" "${_file}.${_backup_extension:-date-failed}"
   unset -v _backup_extension
 fi

--- a/scripts/docker/entrypoint-xftp-server
+++ b/scripts/docker/entrypoint-xftp-server
@@ -36,7 +36,7 @@ fi
 #
 _file="${logd}/file-server-store.log"
 if [ -f "${_file}" ]; then
-  _backup_extension="$(date -u '+%FT%T')"
+  _backup_extension="$(date -u '+%Y-%m-%dT%H:%M:%S')"
   cp -v -p "${_file}" "${_file}.${_backup_extension:-date-failed}"
   unset -v _backup_extension
 fi


### PR DESCRIPTION
Used part of the explicit ISO 8601 format,
provided by the coreutils date invocation guide.